### PR TITLE
根据官方文档添加icon缺少的类型“ReactElement”

### DIFF
--- a/components/button/index.tsx
+++ b/components/button/index.tsx
@@ -9,7 +9,7 @@ export interface ButtonProps extends ButtonPropsType {
   className?: string;
   role?: string;
   inline?: boolean;
-  icon?: string;
+  icon?: string | JSX.Element;
   activeClassName?: string;
   activeStyle?: boolean | CSSProperties;
   style?: React.CSSProperties;


### PR DESCRIPTION
文档原文：“icon,可以是 Icon 组件里内置的某个 icon 的 type 值，也可以是任意合法的 ReactElement (注意: loading设置后此项设置失效)”